### PR TITLE
Make scene detection fall back to first frame

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: python
 python:
 - '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - DB_PASS=
     - DJANGO_SECRET_KEY=kjaslj
     - AWS_SECRET_ACCESS_KEY=asdq3ad
+    - GOOGLE_MAP_API_KEY=asdasd
 addons:
   postgresql: "9.6"
   apt:

--- a/hog/utils.py
+++ b/hog/utils.py
@@ -25,7 +25,9 @@ def make_poster(measurement_id):
         video_location = measurement.video.path
 
     with tempfile.TemporaryDirectory() as d:
-        for delta in ["0.4", "0.2", "0.1", "0.01"]:
+        for delta in ["0.4", "0.2", "0.1", "0"]:
+            # The filter command select=gt(scene,0.3) selects the frames whose # scene detection score is greater then 0.3. We try to find the
+            # most changey scene
             completed = subprocess.run(
                 [
                     "ffmpeg",


### PR DESCRIPTION
Videos with hardly any activity would fail to produce any poster at all. Making the fallback scene detection zero will just give us the first frame after the video starts (so, in fact, the second frame)

Fixes #40