### PR TITLE
Guarantee min cards on wall

### DIFF
--- a/hog/frontend/views.py
+++ b/hog/frontend/views.py
@@ -207,6 +207,8 @@ def grouped_measurements(
     `group_duration` seconds of each other; split measurements of
     different hogs into different groups.
 
+    A group has a "header" which is used for the title and photo header. Then it has one of each of the other kinds of measurements. In other words, we show exactly zero or one of each of a weight, temperature, and video within the same `group_duration`.  The final measurement within in group is the one that is shown.
+
     """
     kwargs = {}
     if hog:

--- a/hog/frontend/views.py
+++ b/hog/frontend/views.py
@@ -218,7 +218,9 @@ def grouped_measurements(
     if most_recent_token:
         kwargs["ordering_token__lt"] = most_recent_token
     max_measurements_per_card = 3  # this is a typical maximum, not including outliers
-    limit = max_cards * max_measurements_per_card
+    limit = min(
+        max_cards * max_measurements_per_card, 2 * 24 * 5
+    )  # at least 5 days of only temp measurements
     measurements = (
         Measurement.objects.filter(**kwargs)
         .exclude(video="", measurement_type="video")


### PR DESCRIPTION
If there's a long string of temperatures only, these are collapsed
into a single card, and the current measurement count limit heuristic
is presumably wrong (needs more thought), leading to only a single
card being displayed.

This is a quick fix to ensure at least 3 days of temps are
considered.  Longer term the logic should change to show at least one
temp card every 4 hours (or so)

Possibly addresses #40
